### PR TITLE
Support Faraday v2.x

### DIFF
--- a/elastic-transport.gemspec
+++ b/elastic-transport.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '>= 1', '< 3'
   s.add_dependency 'multi_json'
 
   # Faraday Adapters

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -200,6 +200,7 @@ describe Elastic::Transport::Client do
       end
 
       let(:client) do
+        require 'faraday/patron'
         described_class.new(adapter: :patron, enable_meta_header: false)
       end
 
@@ -231,6 +232,7 @@ describe Elastic::Transport::Client do
       end
 
       let(:client) do
+        require 'faraday/patron'
         described_class.new(adapter: :patron, enable_meta_header: false)
       end
 
@@ -256,6 +258,8 @@ describe Elastic::Transport::Client do
 
     context 'when the Faraday adapter is configured' do
       let(:client) do
+        require 'faraday/patron'
+
         described_class.new do |faraday|
           faraday.adapter :patron
           faraday.response :logger
@@ -1269,6 +1273,7 @@ describe Elastic::Transport::Client do
           require 'faraday/net_http_persistent' if is_faraday_v2?
 
           let(:client) do
+            require 'faraday/net_http_persistent'
             Elastic::Transport::Client.new(host: ELASTICSEARCH_HOSTS.first, logger: logger) do |client|
               client.adapter(:net_http_persistent)
             end
@@ -1422,6 +1427,7 @@ describe Elastic::Transport::Client do
             require 'faraday/httpclient'
 
             let(:client) do
+              require 'faraday/httpclient'
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :httpclient, enable_meta_header: false)
             end
 
@@ -1458,6 +1464,7 @@ describe Elastic::Transport::Client do
 
           context 'when using the Net::HTTP::Persistent adapter' do
             let(:client) do
+              require 'faraday/net_http_persistent'
               described_class.new(hosts: ELASTICSEARCH_HOSTS, compression: true, adapter: :net_http_persistent)
             end
 

--- a/spec/elastic/transport/meta_header_spec.rb
+++ b/spec/elastic/transport/meta_header_spec.rb
@@ -90,7 +90,10 @@ describe Elastic::Transport::Client do
       let(:headers) { client.transport.connections.first.connection.headers }
 
       context 'using net/http/persistent' do
-        let(:adapter) { :net_http_persistent }
+        let(:adapter) do
+          require 'faraday/net_http_persistent'
+          :net_http_persistent
+        end
 
         it 'sets adapter in the meta header version to 0 when not loaded' do
           was_required = defined?(Net::HTTP::Persistent)
@@ -115,7 +118,10 @@ describe Elastic::Transport::Client do
       end
 
       context 'using httpclient' do
-        let(:adapter) { :httpclient }
+        let(:adapter) do
+          require 'faraday/httpclient'
+          :httpclient
+        end
 
         it 'sets adapter in the meta header version to 0 when not loaded' do
           was_required = defined?(HTTPClient)
@@ -166,7 +172,10 @@ describe Elastic::Transport::Client do
       end unless jruby?
 
       unless jruby?
-        let(:adapter) { :patron }
+        let(:adapter) do
+          require 'faraday/patron'
+          :patron
+        end
 
         context 'using patron without requiring it' do
           it 'sets adapter in the meta header version to 0 when not loaded' do


### PR DESCRIPTION
Following the upgrade guide, this change _should_ be relatively easy, however there is one HTTP adapter which has not yet completed the migration to Faraday v2, and unfortunately upon which these specs rely: https://github.com/typhoeus/typhoeus/issues/686.

### TODO

- [ ] Fix Typhoeus adapters

Closes https://github.com/elastic/elastic-transport-ruby/issues/21