### PR TITLE
Grab all headers from `header_str` when using `Curb`

### DIFF
--- a/lib/elastic/transport/transport/http/curb.rb
+++ b/lib/elastic/transport/transport/http/curb.rb
@@ -55,9 +55,11 @@ module Elastic
               end
 
               connection.connection.http(method.to_sym)
-
+              header_string = connection.connection.header_str.to_s
               response_headers = {}
-              response_headers['content-type'] = 'application/json' if connection.connection.header_str =~ /\/json/
+
+              _response_status, *response_headers = header_string.split(/[\r\n]+/).map(&:strip)
+              response_headers = Hash[response_headers.flat_map{ |s| s.scan(/^(\S+): (.+)/) }].transform_keys(&:downcase)
 
               Response.new connection.connection.response_code,
                            decompress_response(connection.connection.body_str),

--- a/test/integration/transport_test.rb
+++ b/test/integration/transport_test.rb
@@ -93,6 +93,7 @@ class Elastic::Transport::ClientIntegrationTest < Minitest::Test
       assert_respond_to(response.body, :to_hash)
       assert_not_nil response.body['name']
       assert_equal 'application/json', response.headers['content-type']
+      assert_equal 'Elasticsearch', response.headers['x-elastic-product']
     end unless jruby?
   end
 end

--- a/test/unit/transport_curb_test.rb
+++ b/test/unit/transport_curb_test.rb
@@ -83,11 +83,10 @@ else
       should "set application/json response header" do
         @transport.connections.first.connection.expects(:http).with(:GET).returns(stub_everything)
         @transport.connections.first.connection.expects(:body_str).returns('{"foo":"bar"}')
-        @transport.connections.first.connection.expects(:header_str).returns('HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=UTF-8\r\nContent-Length: 311\r\n\r\n')
+        @transport.connections.first.connection.expects(:header_str).returns("HTTP/1.1 200 OK\r\nContent-Type: application/json; charset=UTF-8\r\nContent-Length: 311\r\n\r\n")
 
         response = @transport.perform_request 'GET', '/'
-
-        assert_equal 'application/json', response.headers['content-type']
+        assert_equal 'application/json; charset=UTF-8', response.headers['content-type']
       end
 
       should "handle HTTP methods" do


### PR DESCRIPTION
# The problem

I noticed that I got `Elasticsearch::UnsupportedProductError`
 when using `Curb` as the transport class.

[This is how the Ruby API determines that error](https://github.com/elastic/elasticsearch-ruby/blob/78d83851fb69810c8985672b9a53348c4a61405f/elasticsearch/lib/elasticsearch.rb#L110-L119
):

```Ruby
def verify_with_version_or_header(version, headers)
  if version.nil? ||
      Gem::Version.new(version) < Gem::Version.new('8.0.0.pre') && version != '8.0.0-SNAPSHOT' ||
      headers['x-elastic-product'] != 'Elasticsearch'

    raise Elasticsearch::UnsupportedProductError
  end

  @verified = true
end
``` 

After putting some `p`'s around, I could determine that the header `x-elastic-product` is not passed when using `Curb` as the transport class, along some other header parameters.

## Repro

```yaml
# docker-compose.yml
version: "3.1"

services:
  db:
    image: elasticsearch:8.0.1
    environment:
      - xpack.security.enabled=false
      - xpack.security.http.ssl.enabled=false
      - discovery.type=single-node
    ports:
      - 9200:9200
    command: bin/elasticsearch
``` 

```
gem versions:
elasticsearch (8.2.2)
    elastic-transport (= 8.0.1)
    elasticsearch-api (= 8.2.2)
```

```ruby
require "curb"
require "elasticsearch"
require "elastic/transport/transport/http/curb"

hosts = [{host: "localhost", port: 9200 }]
args = { hosts: hosts}

transport_curb = Elastic::Transport::Transport::HTTP::Curb.new(args)
transport_faraday = Elastic::Transport::Transport::HTTP::Faraday.new(args)


p transport_curb.perform_request("GET", "/")
#<Elastic::Transport::Transport::Response:0x00007f7f0269fc70 @headers={"content-type"=>"application/json"}, @body={"name"=>"25ec6cf5e464", "cluster_name"=>"docker-cluster", "cluster_uuid"=>"Js_9nTKBQf6PDputTzkcjA", "version"=>{"number"=>"8.0.1", "build_flavor"=>"default", "build_type"=>"docker", "build_hash"=>"801d9ccc7c2ee0f2cb121bbe22ab5af77a902372", "build_date"=>"2022-02-24T13:55:40.601285296Z", "build_snapshot"=>false, "lucene_version"=>"9.0.0", "minimum_wire_compatibility_version"=>"7.17.0", "minimum_index_compatibility_version"=>"7.0.0"}, "tagline"=>"You Know, for Search"}, @status=200>

p transport_faraday.perform_request("GET", "/")
#<Elastic::Transport::Transport::Response:0x00007f7f0263ed08 @headers={"x-elastic-product"=>"Elasticsearch", "content-type"=>"application/json", "content-length"=>"326"}, @body={"name"=>"25ec6cf5e464", "cluster_name"=>"docker-cluster", "cluster_uuid"=>"Js_9nTKBQf6PDputTzkcjA", "version"=>{"number"=>"8.0.1", "build_flavor"=>"default", "build_type"=>"docker", "build_hash"=>"801d9ccc7c2ee0f2cb121bbe22ab5af77a902372", "build_date"=>"2022-02-24T13:55:40.601285296Z", "build_snapshot"=>false, "lucene_version"=>"9.0.0", "minimum_wire_compatibility_version"=>"7.17.0", "minimum_index_compatibility_version"=>"7.0.0"}, "tagline"=>"You Know, for Search"}, @status=200>
``` 

Note the `@headers` instance variable.

## The fix

Found this SO [thread](https://stackoverflow.com/a/14353011) where this example of grabbing all the headers from `header_str`.

```diff
diff --git a/lib/elastic/transport/transport/http/curb.rb b/lib/elastic/transport/transport/http/curb.rb
index c082a46..607b736 100644
--- a/lib/elastic/transport/transport/http/curb.rb
+++ b/lib/elastic/transport/transport/http/curb.rb
@@ -55,9 +55,11 @@ module Elastic
               end
 
               connection.connection.http(method.to_sym)
-
+              header_string = connection.connection.header_str.to_s
               response_headers = {}
-              response_headers['content-type'] = 'application/json' if connection.connection.header_str =~ /\/json/
+
+              _response_status, *response_headers = header_string.split(/[\r\n]+/).map(&:strip)
+              response_headers = Hash[response_headers.flat_map{ |s| s.scan(/^(\S+): (.+)/) }].transform_keys(&:downcase)
 
               Response.new connection.connection.response_code,
                            decompress_response(connection.connection.body_str),

```

After applying above fix, I got this result:

```ruby
require "curb"
require "elasticsearch"
require_relative "../elastic-transport-ruby/lib/elastic/transport/transport/http/curb"
require_relative "../elastic-transport-ruby/lib/elastic/transport/transport/http/faraday"

hosts = [{host: "localhost", port: 9200 }]
args = { hosts: hosts}

transport_curb = Elastic::Transport::Transport::HTTP::Curb.new(args)

p transport_curb.perform_request("GET", "/")
#<Elastic::Transport::Transport::Response:0x00007faf46ad57d0 @headers={"x-elastic-product"=>"Elasticsearch", "content-type"=>"application/json", "content-length"=>"539"}, @body={"name"=>"25ec6cf5e464", "cluster_name"=>"docker-cluster", "cluster_uuid"=>"Js_9nTKBQf6PDputTzkcjA", "version"=>{"number"=>"8.0.1", "build_flavor"=>"default", "build_type"=>"docker", "build_hash"=>"801d9ccc7c2ee0f2cb121bbe22ab5af77a902372", "build_date"=>"2022-02-24T13:55:40.601285296Z", "build_snapshot"=>false, "lucene_version"=>"9.0.0", "minimum_wire_compatibility_version"=>"7.17.0", "minimum_index_compatibility_version"=>"7.0.0"}, "tagline"=>"You Know, for Search"}, @status=200>
```

Now finally the missing header is being passed. :)