### PR TITLE
Raises Elastic::Transport::Transport::Error when host unreachable and other updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,6 +110,15 @@ namespace :docker do
   end
 end
 
+desc 'Run Ruby console with the Elastic transport client libraries loaded'
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'elastic-transport'
+  ARGV.clear
+  IRB.start
+end
+
 # ----- Documentation tasks ---------------------------------------------------
 require 'yard'
 YARD::Rake::YardocTask.new(:doc) do |t|

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -322,16 +322,18 @@ module Elastic
               reload_connections! and retry
             end
 
+            exception = Elastic::Transport::Transport::Error.new(e.message)
+
             if max_retries
               log_warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}"
               if tries <= max_retries
                 retry
               else
                 log_fatal "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries"
-                raise e
+                raise exception
               end
             else
-              raise e
+              raise exception
             end
           rescue Exception => e
             log_fatal "[#{e.class}] #{e.message} (#{connection.host.inspect if connection})"

--- a/lib/elastic/transport/transport/http/faraday.rb
+++ b/lib/elastic/transport/transport/http/faraday.rb
@@ -74,10 +74,10 @@ module Elastic
           #
           def host_unreachable_exceptions
             [
-                ::Faraday::ConnectionFailed,
-                ::Faraday::TimeoutError,
-                ::Faraday.const_defined?(:ServerError) ? ::Faraday::ServerError : nil,
-                ::Faraday::SSLError
+              ::Faraday::ConnectionFailed,
+              ::Faraday::TimeoutError,
+              ::Faraday.const_defined?(:ServerError) ? ::Faraday::ServerError : nil,
+              ::Faraday::SSLError
             ].compact
           end
 
@@ -85,14 +85,14 @@ module Elastic
 
           def user_agent_header(client)
             @user_agent ||= begin
-              meta = ["RUBY_VERSION: #{RUBY_VERSION}"]
-              if RbConfig::CONFIG && RbConfig::CONFIG['host_os']
-                meta << "#{RbConfig::CONFIG['host_os'].split('_').first[/[a-z]+/i].downcase} " \
-                        "#{RbConfig::CONFIG['target_cpu']}"
-              end
-              meta << client.headers[USER_AGENT_STR]
-              "elastic-transport-ruby/#{VERSION} (#{meta.join('; ')})"
-            end
+                              meta = ["RUBY_VERSION: #{RUBY_VERSION}"]
+                              if RbConfig::CONFIG && RbConfig::CONFIG['host_os']
+                                meta << "#{RbConfig::CONFIG['host_os'].split('_').first[/[a-z]+/i].downcase} " \
+                                        "#{RbConfig::CONFIG['target_cpu']}"
+                              end
+                              meta << client.headers[USER_AGENT_STR]
+                              "elastic-transport-ruby/#{VERSION} (#{meta.join('; ')})"
+                            end
           end
         end
       end

--- a/spec/elastic/transport/base_spec.rb
+++ b/spec/elastic/transport/base_spec.rb
@@ -30,16 +30,16 @@ describe Elastic::Transport::Transport::Base do
 
       it 'does not include the password in the logged string' do
         expect(logger).not_to receive(:error).with(/secret_password/)
-        expect {
+        expect do
           client.perform_request('GET', '/_cluster/stats')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
 
       it 'replaces the password with the string \'REDACTED\'' do
         expect(logger).to receive(:error).with(/REDACTED/)
-        expect {
+        expect do
           client.perform_request('GET', '/_cluster/stats')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
 
@@ -93,7 +93,7 @@ describe Elastic::Transport::Transport::Base do
     end
 
     it 'raises an exception' do
-      expect { client.perform_request('GET', '/info') }.to raise_exception(Faraday::ConnectionFailed)
+      expect { client.perform_request('GET', '/info') }.to raise_exception(Elastic::Transport::Transport::Error)
     end
   end
 
@@ -116,9 +116,9 @@ describe Elastic::Transport::Transport::Base do
       end
 
       it 'uses the client `retry_on_failure` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
 
@@ -150,7 +150,7 @@ describe Elastic::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
   end
@@ -162,8 +162,8 @@ describe Elastic::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-          retry_on_failure: true
+        hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
+        retry_on_failure: true
       }
     end
 
@@ -173,9 +173,9 @@ describe Elastic::Transport::Transport::Base do
       end
 
       it 'uses the default `MAX_RETRIES` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
 
@@ -185,9 +185,9 @@ describe Elastic::Transport::Transport::Base do
       end
 
       it 'uses the option `retry_on_failure` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
   end
@@ -199,8 +199,8 @@ describe Elastic::Transport::Transport::Base do
 
     let(:arguments) do
       {
-          hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
-          retry_on_failure: false
+        hosts: ['http://unavailable:9200', 'http://unavailable:9201'],
+        retry_on_failure: false
       }
     end
 
@@ -210,22 +210,21 @@ describe Elastic::Transport::Transport::Base do
       end
 
       it 'does not retry' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info')
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
 
     context 'when `perform_request` is called with a `retry_on_failure` option value' do
-
       before do
         expect(client.transport).to receive(:get_connection).exactly(6).times.and_call_original
       end
 
       it 'uses the option `retry_on_failure` value' do
-        expect {
+        expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        }.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
   end
@@ -247,7 +246,7 @@ describe Elastic::Transport::Transport::Base do
       it 'does not retry' do
         expect do
           client.transport.perform_request('GET', '/info')
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
 
@@ -259,7 +258,7 @@ describe Elastic::Transport::Transport::Base do
       it 'uses the option `retry_on_failure` value' do
         expect do
           client.transport.perform_request('GET', '/info', {}, nil, nil, retry_on_failure: 5)
-        end.to raise_exception(Faraday::ConnectionFailed)
+        end.to raise_exception(Elastic::Transport::Transport::Error)
       end
     end
   end

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -1327,9 +1327,9 @@ describe Elastic::Transport::Client do
 
         it 'retries only the specified number of times' do
           expect(client.perform_request('GET', '_nodes/_local'))
-          expect {
+          expect do
             client.perform_request('GET', '_nodes/_local')
-          }.to raise_exception(Faraday::ConnectionFailed)
+          end.to raise_exception(Elastic::Transport::Transport::Error)
         end
       end
 

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -1194,17 +1194,7 @@ describe Elastic::Transport::Client do
 
   context 'when the client connects to Elasticsearch' do
     let(:logger) do
-      Logger.new(STDERR).tap do |logger|
-        logger.formatter = proc do |severity, datetime, progname, msg|
-          color = case severity
-                  when /INFO/ then :green
-                  when /ERROR|WARN|FATAL/ then :red
-                  when /DEBUG/ then :cyan
-                  else :white
-                  end
-          ANSI.ansi(severity[0] + ' ', color, :faint) + ANSI.ansi(msg, :white, :faint) + "\n"
-        end
-      end unless ENV['QUIET']
+      Logger.new($stderr) unless ENV['QUIET']
     end
 
     let(:port) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ end
 
 require 'elastic-transport'
 require 'logger'
-require 'ansi/code'
 require 'hashie/mash'
 if defined?(JRUBY_VERSION)
   require 'elastic/transport/transport/http/manticore'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,6 @@ if ENV['COVERAGE']
   SimpleCov.start { add_filter %r{^/test/} }
 end
 
-require 'ansi/code'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'mocha/minitest'

--- a/test/unit/transport_base_test.rb
+++ b/test/unit/transport_base_test.rb
@@ -255,10 +255,9 @@ class Elastic::Transport::Transport::BaseTest < Minitest::Test
     should "raise an error on connection failure" do
       @transport.expects(:get_connection).returns(stub_everything :failures => 1)
 
-      # `block.expects(:call).raises(::Errno::ECONNREFUSED)` fails on Ruby 1.8
-      block = lambda { |a,b| raise ::Errno::ECONNREFUSED }
+      block = lambda { |a,b| raise Elastic::Transport::Transport::Error }
 
-      assert_raise ::Errno::ECONNREFUSED do
+      assert_raise Elastic::Transport::Transport::Error do
         @transport.perform_request 'GET', '/', &block
       end
     end
@@ -291,11 +290,11 @@ class Elastic::Transport::Transport::BaseTest < Minitest::Test
       c = stub_everything :failures => 1
       @transport.expects(:get_connection).returns(c)
 
-      block = lambda { |a,b| raise ::Errno::ECONNREFUSED }
+      block = lambda { |a, b| raise Errno::ECONNREFUSED }
 
       c.expects(:dead!)
 
-      assert_raise( ::Errno::ECONNREFUSED ) { @transport.perform_request 'GET', '/', &block }
+      assert_raise( Elastic::Transport::Transport::Error ) { @transport.perform_request 'GET', '/', &block }
     end
   end
 
@@ -311,7 +310,7 @@ class Elastic::Transport::Transport::BaseTest < Minitest::Test
 
     should "reload connections when host is unreachable" do
       @block.expects(:call).times(2).
-            raises(Errno::ECONNREFUSED).
+        raises(Errno::ECONNREFUSED).
             then.returns(stub_everything :failures => 1)
 
       @transport.expects(:reload_connections!).returns([])
@@ -343,13 +342,13 @@ class Elastic::Transport::Transport::BaseTest < Minitest::Test
 
     should "raise an error after max tries" do
       @block.expects(:call).times(4).
-            raises(Errno::ECONNREFUSED).
+        raises(Errno::ECONNREFUSED).
             then.raises(Errno::ECONNREFUSED).
             then.raises(Errno::ECONNREFUSED).
             then.raises(Errno::ECONNREFUSED).
             then.returns(stub_everything :failures => 1)
 
-      assert_raise Errno::ECONNREFUSED do
+      assert_raise Elastic::Transport::Transport::Error do
         @transport.perform_request('GET', '/', &@block)
       end
     end


### PR DESCRIPTION
In our documentation we say:
> The highest-level exception is `Elastic::Transport::Transport::Error` and is raised for any
> generic client or server errors.

However, when we got a host unreachable error, we would raise the http implementation's exception
instead of Transport Error. This updates the code so we log the original exception, but raise our
high level exception.

Closes https://github.com/elastic/elastic-transport-ruby/issues/44