### PR TITLE
Fix parsing of inet[/127.0.0.1:9200]

### DIFF
--- a/lib/elastic/transport/transport/sniffer.rb
+++ b/lib/elastic/transport/transport/sniffer.rb
@@ -80,6 +80,8 @@ module Elastic
           # - hostname/ip:port
           # - inet[hostname/ip:port]
           publish_address = publish_address[5..-2] if publish_address =~ /^inet\[.*\]$/
+          # If hostname is empty.
+          publish_address = publish_address[1..] if publish_address =~ /^\//
           if publish_address =~ /\//
             parts = publish_address.partition('/')
             [ parts[0], parse_address_port(parts[2])[1] ]

--- a/lib/elastic/transport/transport/sniffer.rb
+++ b/lib/elastic/transport/transport/sniffer.rb
@@ -76,7 +76,10 @@ module Elastic
         end
 
         def parse_publish_address(publish_address)
-          # publish_address is in the format hostname/ip:port
+          # publish_address is in the format:
+          # - hostname/ip:port
+          # - inet[hostname/ip:port]
+          publish_address = publish_address[5..-2] if publish_address =~ /^inet\[.*\]$/
           if publish_address =~ /\//
             parts = publish_address.partition('/')
             [ parts[0], parse_address_port(parts[2])[1] ]


### PR DESCRIPTION
Detected while upgrading application from `elasticsearch-transport-1.0.6` to `elastic-transport-8`

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>