### PR TITLE
Normalize on @arguments ivar

### DIFF
--- a/lib/elastic/transport/client.rb
+++ b/lib/elastic/transport/client.rb
@@ -122,8 +122,7 @@ module Elastic
       # @yield [faraday] Access and configure the `Faraday::Connection` instance directly with a block
       #
       def initialize(arguments = {}, &block)
-        @options = arguments.transform_keys(&:to_sym)
-        @arguments = @options
+        @arguments = arguments.transform_keys(&:to_sym)
         @arguments[:logger] ||= @arguments[:log]   ? DEFAULT_LOGGER.call() : nil
         @arguments[:tracer] ||= @arguments[:trace] ? DEFAULT_TRACER.call() : nil
         @arguments[:reload_connections] ||= false
@@ -134,7 +133,6 @@ module Elastic
         @arguments[:transport_options]  ||= {}
         @arguments[:http]               ||= {}
         @arguments[:enable_meta_header] = arguments.fetch(:enable_meta_header, true)
-        @options[:http]                 ||= {}
 
         @hosts ||= __extract_hosts(@arguments[:hosts] ||
                                    @arguments[:host] ||
@@ -236,7 +234,7 @@ module Elastic
                 end
 
         host_list = hosts.map { |host| __parse_host(host) }
-        @options[:randomize_hosts] ? host_list.shuffle! : host_list
+        @arguments[:randomize_hosts] ? host_list.shuffle! : host_list
       end
 
       def __parse_host(host)
@@ -273,8 +271,8 @@ module Elastic
                        raise ArgumentError, "Please pass host as a String, URI or Hash -- #{host.class} given."
                      end
 
-        @options[:http][:user] ||= host_parts[:user]
-        @options[:http][:password] ||= host_parts[:password]
+        @arguments[:http][:user] ||= host_parts[:user]
+        @arguments[:http][:password] ||= host_parts[:password]
         host_parts[:port] = host_parts[:port].to_i if host_parts[:port]
         host_parts[:path].chomp!('/') if host_parts[:path]
         host_parts


### PR DESCRIPTION
Some git-blame spelunking shows that we used to only have `@arguments`, [but changed it to `@options` when converting to RSpec](https://github.com/stevenharman/elastic-transport-ruby/commit/0eb78425a137a62479f80a35ae8a07496150d804). We then quickly [switched (mostly) back to using `@arguments`](https://github.com/stevenharman/elastic-transport-ruby/commit/5fb91c81bca7bed0701afb3809c5fb73d66d9bc6), but seem to have missed `@options` in a couple of spots. This finishes that cleanup.

We were creating an `@options` ivar, then creating a second ivar named `@arguments`, which pointed at the same Ruby object. We mostly use the `@arguments` ivar, and occasionally double-initialize values (`:http`) in the `@options`. This normalizes on the `@arguments` ivar.