### PR TITLE
Refactors apply_headers in base and manticore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.2.2
+
+Tested versions of Ruby: (MRI) 3.0, 3.1, 3.2, JRuby 9.3 and JRuby 9.4
+
+- Refactors `apply_headers` in base and manticore implementation: When passing in an object to the initializer, `apply_headers` would mutate this object and in certain conditions, this would raise `RuntimeError` in JRuby 9.3 and `ConcurrencyError` in JRuby 9.4. This update clones the options object instead.
+
 ## 8.2.1
 
 Tested versions of Ruby: (MRI) 2.7, 3.0, 3.1, 3.2, JRuby 9.3 and JRuby 9.4. Ruby 2.7's end of life is coming in a few days, so this'll probably be the last release to test for Ruby 2.7.

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -431,7 +431,7 @@ module Elastic
         end
 
         def apply_headers(client, options)
-          headers = options[:headers] || {}
+          headers = options[:headers].clone || {}
           headers[CONTENT_TYPE_STR] = find_value(headers, CONTENT_TYPE_REGEX) || DEFAULT_CONTENT_TYPE
           headers[USER_AGENT_STR] = find_value(headers, USER_AGENT_REGEX) || user_agent_header(client)
           client.headers[ACCEPT_ENCODING] = GZIP if use_compression?

--- a/lib/elastic/transport/transport/http/manticore.rb
+++ b/lib/elastic/transport/transport/http/manticore.rb
@@ -162,7 +162,7 @@ module Elastic
           private
 
           def apply_headers(options)
-            headers = options[:headers] || options.dig(:transport_options, :headers) || {}
+            headers = options[:headers].clone || options.dig(:transport_options, :headers).clone || {}
             headers[CONTENT_TYPE_STR] = find_value(headers, CONTENT_TYPE_REGEX) || DEFAULT_CONTENT_TYPE
             headers[USER_AGENT_STR] = find_value(headers, USER_AGENT_REGEX) || find_value(@request_options[:headers], USER_AGENT_REGEX) || user_agent_header
             headers[ACCEPT_ENCODING] = GZIP if use_compression?

--- a/lib/elastic/transport/version.rb
+++ b/lib/elastic/transport/version.rb
@@ -17,6 +17,6 @@
 
 module Elastic
   module Transport
-    VERSION = '8.2.1'.freeze
+    VERSION = '8.2.2'.freeze
   end
 end


### PR DESCRIPTION
When passing in an object to the initializer, `apply_headers` would mutate this object and in certain conditions, this would raise `RuntimeError` in JRuby 9.3 and `ConcurrencyError` in JRuby 9.4. This update clones the options object instead.