### PR TITLE
Doesn't enforce UTF-8 encoding in Response object if the string is frozen

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         es_version: ['8.7-SNAPSHOT', '8.8-SNAPSHOT', '8.9-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Increase system limits
       run: |
         sudo swapoff -a
@@ -57,7 +57,7 @@ jobs:
         es_version: ['8.9-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Increase system limits
       run: |
         sudo swapoff -a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.2.3
+
+Tested versions of Ruby: (MRI) 3.0, 3.1, 3.2, JRuby 9.3 and JRuby 9.4
+
+- Fixes enforcing UTF-8 in Response body, causing an error when the string is frozen, particularly when using webmock. [issue #63](https://github.com/elastic/elastic-transport-ruby/issues/63)
+
 ## 8.2.2
 
 Tested versions of Ruby: (MRI) 3.0, 3.1, 3.2, JRuby 9.3 and JRuby 9.4

--- a/lib/elastic/transport/transport/response.rb
+++ b/lib/elastic/transport/transport/response.rb
@@ -19,8 +19,7 @@ module Elastic
   module Transport
     module Transport
       # Wraps the response from Elasticsearch.
-      # It provides `body`, `status` and `headers` methods, but you can treat is as a hash and
-      # access the keys directly.
+      # It provides `body`, `status` and `headers` methods
       class Response
         attr_reader :status, :body, :headers
 
@@ -29,7 +28,7 @@ module Elastic
         # @param headers [Hash]    Response headers
         def initialize(status, body, headers = {})
           @status, @body, @headers = status, body, headers
-          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding)
+          @body = body.force_encoding('UTF-8') if body.respond_to?(:force_encoding) && !body.frozen?
         end
       end
     end

--- a/lib/elastic/transport/version.rb
+++ b/lib/elastic/transport/version.rb
@@ -17,6 +17,6 @@
 
 module Elastic
   module Transport
-    VERSION = '8.2.2'.freeze
+    VERSION = '8.2.3'.freeze
   end
 end


### PR DESCRIPTION
Elasticsearch responses are UTF-8 encoded.
Cloning the string instead could be very expensive.

Fixes #63