### PR TITLE
Prevent Float value from automatically becoming BigDecimal when using Oj

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'faraday-patron' unless defined? JRUBY_VERSION
   gem 'faraday-typhoeus'
   gem 'rspec'
+  gem 'oj'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
   gem 'faraday-patron' unless defined? JRUBY_VERSION
   gem 'faraday-typhoeus'
   gem 'rspec'
-  gem 'oj'
+  gem 'oj' unless defined? JRUBY_VERSION
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else

--- a/Gemfile-faraday1.gemfile
+++ b/Gemfile-faraday1.gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'patron' unless defined? JRUBY_VERSION
   gem 'rspec'
   gem 'typhoeus'
-  gem 'oj'
+  gem 'oj' unless defined? JRUBY_VERSION
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else

--- a/Gemfile-faraday1.gemfile
+++ b/Gemfile-faraday1.gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'patron' unless defined? JRUBY_VERSION
   gem 'rspec'
   gem 'typhoeus'
+  gem 'oj'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
   else

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -353,7 +353,7 @@ module Elastic
 
             # Prevent Float value from automatically becoming BigDecimal when using Oj
             load_options = {}
-            load_options[:mode] = :compat if serializer.is_a?(Serializer::MultiJson) && defined?(::Oj)
+            load_options[:mode] = :compat if ::MultiJson.adapter.to_s == "MultiJson::Adapters::Oj"
 
             json = serializer.load(response.body, load_options)
           end

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -346,10 +346,17 @@ module Elastic
             __raise_transport_error response unless ignore.include?(response.status.to_i)
           end
 
-          json = serializer.load(response.body) if response.body &&
-                                                       !response.body.empty? &&
-                                                       response.headers &&
-                                                       response.headers["content-type"] =~ /json/
+          if response.body &&
+            !response.body.empty? &&
+            response.headers &&
+            response.headers["content-type"] =~ /json/
+
+            # Prevent Float value from automatically becoming BigDecimal when using Oj
+            options = {}
+            options[:mode] = :compat if serializer.is_a?(Serializer::MultiJson) && defined?(::Oj)
+
+            json = serializer.load(response.body, options)
+          end
           took = (json['took'] ? sprintf('%.3fs', json['took'] / 1000.0) : 'n/a') rescue 'n/a'
           __log_response(method, path, params, body, url, response, json, took, duration) unless ignore.include?(response.status.to_i)
           __trace(method, path, params, connection_headers(connection), body, url, response, nil, 'N/A', duration) if tracer

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -352,10 +352,10 @@ module Elastic
             response.headers["content-type"] =~ /json/
 
             # Prevent Float value from automatically becoming BigDecimal when using Oj
-            options = {}
-            options[:mode] = :compat if serializer.is_a?(Serializer::MultiJson) && defined?(::Oj)
+            load_options = {}
+            load_options[:mode] = :compat if serializer.is_a?(Serializer::MultiJson) && defined?(::Oj)
 
-            json = serializer.load(response.body, options)
+            json = serializer.load(response.body, load_options)
           end
           took = (json['took'] ? sprintf('%.3fs', json['took'] / 1000.0) : 'n/a') rescue 'n/a'
           __log_response(method, path, params, body, url, response, json, took, duration) unless ignore.include?(response.status.to_i)

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -1213,22 +1213,24 @@ describe Elastic::Transport::Client do
         end
       end
 
-      context 'when Oj is used as a JSON engine' do
-        before do
-          require 'oj'
-        end
-        after do
-          # Clear unnecessary Oj
-          Object.send(:remove_const, :Oj)
-          # Clear MultiJson's adapter
-          ::MultiJson.instance_variable_set(:@adapter, nil)
-        end
+      unless defined?(JRUBY_VERSION)
+        context 'when Oj is used as a JSON engine' do
+          before do
+            require 'oj'
+          end
+          after do
+            # Clear unnecessary Oj
+            Object.send(:remove_const, :Oj)
+            # Clear MultiJson's adapter
+            ::MultiJson.instance_variable_set(:@adapter, nil)
+          end
 
-        it 'returns as a Float' do
-          response = client.perform_request('GET', '/')
-          score = response.body['score']
-          expect(score).to eq 1.11111111111111111
-          expect(score.class).to eq Float
+          it 'returns as a Float' do
+            response = client.perform_request('GET', '/')
+            score = response.body['score']
+            expect(score).to eq 1.11111111111111111
+            expect(score.class).to eq Float
+          end
         end
       end
     end

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -1196,15 +1196,16 @@ describe Elastic::Transport::Client do
         Elastic::Transport::Client.new(hosts: hosts)
       end
       before do
-        # Clear MultiJson's adapter
-        ::MultiJson.instance_variable_set(:@adapter, nil)
-
         expect_any_instance_of(Faraday::Connection).to receive(:run_request) do
           Elastic::Transport::Transport::Response.new(200, "{\"score\":1.11111111111111111}", { 'content-type' => 'application/json; charset=UTF-8' })
         end
       end
 
       context 'when default JSON engine is used' do
+        after do
+          # Clear MultiJson's adapter
+          ::MultiJson.instance_variable_set(:@adapter, nil)
+        end
         it 'returns as a Float' do
           response = client.perform_request('GET', '/')
           score = response.body['score']
@@ -1219,8 +1220,6 @@ describe Elastic::Transport::Client do
             require 'oj'
           end
           after do
-            # Clear unnecessary Oj
-            Object.send(:remove_const, :Oj)
             # Clear MultiJson's adapter
             ::MultiJson.instance_variable_set(:@adapter, nil)
           end


### PR DESCRIPTION
Fixes #67

Only `compat` mode cat prevent automatically becoming BigDecimal when using oj.