### PR TITLE
Updates OpenTelemetry conventions

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.4'
+        ruby-version: '4.0'
     - name: Check license headers
       run: |
         ruby ./.github/check_license_headers.rb

--- a/.github/workflows/otel.yml
+++ b/.github/workflows/otel.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['4.0', 'jruby-9.4']
-        es_version: ['9.3.0-SNAPSHOT']
+        es_version: ['9.4.0-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2', '3.3', '3.4', '4.0', 'jruby-9.3', 'jruby-9.4', 'jruby-10.0']
-        es_version: ['8.18.8-SNAPSHOT', '8.19.10-SNAPSHOT', '9.1.10-SNAPSHOT', '9.2.4-SNAPSHOT', '9.3.0-SNAPSHOT']
+        es_version: ['8.19.14-SNAPSHOT', '9.2.8-SNAPSHOT', '9.3.3-SNAPSHOT', '9.4.0-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.0', '3.1', '3.2', '3.3', 'jruby-9.3']
-        es_version: ['8.19.5-SNAPSHOT']
+        es_version: ['8.19.14-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/elastic-transport.gemspec
+++ b/elastic-transport.gemspec
@@ -48,7 +48,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json'
 
   # Faraday Adapters
-  s.add_development_dependency 'manticore' if defined? JRUBY_VERSION
+  if defined? JRUBY_VERSION
+    s.add_development_dependency 'manticore'
+    s.add_development_dependency 'base64'
+  end
   s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'

--- a/lib/elastic/transport/client.rb
+++ b/lib/elastic/transport/client.rb
@@ -174,18 +174,19 @@ module Elastic
           span_name = opts[:endpoint] || method
           @otel.tracer.in_span(span_name) do |span|
             span['http.request.method'] = method
-            span['db.system'] = 'elasticsearch'
+            span['db.system.name'] = 'elasticsearch'.freeze
+            span['kind'] = 'CLIENT'.freeze
             opts[:defined_params]&.each do |k, v|
-              span["db.elasticsearch.path_parts.#{k}"] = if v.respond_to?(:join)
-                                                           v.join(',')
-                                                         else
-                                                           v
-                                                         end
+              span["db.operation.parameter.#{k}"] = if v.respond_to?(:join)
+                                                      v.join(',')
+                                                    else
+                                                      v
+                                                    end
             end
             if (body_as_json = @otel.process_body(body, opts[:endpoint]))
-              span['db.statement'] = body_as_json
+              span['db.query.text'] = body_as_json
             end
-            span['db.operation'] = opts[:endpoint] if opts[:endpoint]
+            span['db.operation.name'] = opts[:endpoint] if opts[:endpoint]
             transport.perform_request(method, path, params || {}, body, headers)
           end
         else

--- a/lib/elastic/transport/client.rb
+++ b/lib/elastic/transport/client.rb
@@ -176,13 +176,13 @@ module Elastic
             span['http.request.method'] = method
             span['db.system'] = 'elasticsearch'
             opts[:defined_params]&.each do |k, v|
-              if v.respond_to?(:join)
-                span["db.elasticsearch.path_parts.#{k}"] = v.join(',')
-              else
-                span["db.elasticsearch.path_parts.#{k}"] = v
-              end
+              span["db.elasticsearch.path_parts.#{k}"] = if v.respond_to?(:join)
+                                                           v.join(',')
+                                                         else
+                                                           v
+                                                         end
             end
-            if body_as_json = @otel.process_body(body, opts[:endpoint])
+            if (body_as_json = @otel.process_body(body, opts[:endpoint]))
               span['db.statement'] = body_as_json
             end
             span['db.operation'] = opts[:endpoint] if opts[:endpoint]
@@ -271,27 +271,28 @@ module Elastic
                          # Construct a new `URI::Generic` directly from the array returned by URI::split.
                          # This avoids `URI::HTTP` and `URI::HTTPS`, which supply default ports.
                          uri = URI::Generic.new(*URI.split(host))
-
                          default_port = uri.scheme == 'https' ? 443 : DEFAULT_PORT
-
-                         { :scheme => uri.scheme,
-                           :user => uri.user,
-                           :password => uri.password,
-                           :host => uri.host,
-                           :path => uri.path,
-                           :port => uri.port || default_port }
+                         {
+                           scheme: uri.scheme,
+                           user: uri.user,
+                           password: uri.password,
+                           host: uri.host,
+                           path: uri.path,
+                           port: uri.port || default_port
+                         }
                        else
                          host, port = host.split(':')
-                         { :host => host,
-                           :port => port }
+                         { host: host, port: port }
                        end
                      when URI
-                       { :scheme => host.scheme,
-                         :user => host.user,
-                         :password => host.password,
-                         :host => host.host,
-                         :path => host.path,
-                         :port => host.port }
+                       {
+                         scheme: host.scheme,
+                         user: host.user,
+                         password: host.password,
+                         host: host.host,
+                         path: host.path,
+                         port: host.port
+                       }
                      when Hash
                        host
                      else

--- a/lib/elastic/transport/opentelemetry.rb
+++ b/lib/elastic/transport/opentelemetry.rb
@@ -42,6 +42,8 @@ module Elastic
         'async_search.submit',
         'msearch',
         'eql.search',
+        'esql.async_query',
+        'esql.query',
         'terms_enum',
         'search_template',
         'msearch_template',

--- a/lib/elastic/transport/opentelemetry.rb
+++ b/lib/elastic/transport/opentelemetry.rb
@@ -45,7 +45,7 @@ module Elastic
         'terms_enum',
         'search_template',
         'msearch_template',
-        'render_search_template',
+        'render_search_template'
       ]
 
       # Initialize the Open Telemetry wrapper object. Takes the options originally passed to

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -232,8 +232,8 @@ module Elastic
         #
         # @api private
         #
-        def __convert_to_json(o = nil, options = {})
-          o.is_a?(String) ? o : serializer.dump(o, options)
+        def __convert_to_json(obj = nil, options = {})
+          obj.is_a?(String) ? obj : serializer.dump(obj, options)
         end
 
         # Returns a full URL based on information from host

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -371,6 +371,10 @@ module Elastic
           __trace(method, path, params, connection_headers(connection), body, url, response, nil, 'N/A', duration) if tracer
           log_warn(response.headers['warning']) if response.headers&.[]('warning')
 
+          if opentelemetry?
+            ::OpenTelemetry::Trace.current_span&.set_attribute('db.response.status_code', response.status)
+          end
+
           Response.new response.status, json || response.body, response.headers
         ensure
           @last_request_at = Time.now

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -225,7 +225,9 @@ module Elastic
         #
         def __raise_transport_error(response)
           error = ERRORS[response.status] || ServerError
-          raise error.new "[#{response.status}] #{response.body}"
+          message = "[#{response.status}] #{response.body}"
+          capture_otel_error_attributes(message)
+          raise error.new message
         end
 
         # Converts any non-String object to JSON
@@ -275,9 +277,7 @@ module Elastic
           tries = 0
           reload_on_failure = opts.fetch(:reload_on_failure, @options[:reload_on_failure])
           delay_on_retry = opts.fetch(:delay_on_retry, @options[:delay_on_retry])
-
           max_retries = max_retries(opts) || max_retries(options)
-
           params = params.clone
           # Transforms ignore status codes to Integer
           ignore = Array(params.delete(:ignore)).compact.map(&:to_i)
@@ -306,7 +306,9 @@ module Elastic
             if tries <= (max_retries || DEFAULT_MAX_RETRIES)
               retry
             else
-              log_fatal "[#{e.class}] Cannot get response from #{url} after #{tries} tries"
+              message = "[#{e.class}] Cannot get response from #{url} after #{tries} tries"
+              log_fatal(message)
+              capture_otel_error_attributes(message)
               raise e
             end
           rescue *host_unreachable_exceptions => e
@@ -321,17 +323,24 @@ module Elastic
 
             exception = Elastic::Transport::Transport::Error.new(e.message)
 
-            raise exception unless max_retries
+            unless max_retries
+              capture_otel_error_attributes(exception.message)
+              raise exception
+            end
 
             log_warn "[#{e.class}] Attempt #{tries} connecting to #{connection.host.inspect}"
             if tries <= max_retries
               retry
             else
-              log_fatal "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries"
+              message = "[#{e.class}] Cannot connect to #{connection.host.inspect} after #{tries} tries"
+              log_fatal(message)
+              capture_otel_error_attributes(message)
               raise exception
             end
           rescue Exception => e
-            log_fatal "[#{e.class}] #{e.message} (#{connection.host.inspect if connection})"
+            message = "[#{e.class}] #{e.message} (#{connection.host.inspect if connection})"
+            log_fatal message
+            capture_otel_error_attributes(message)
             raise e
           end #/begin
 
@@ -476,11 +485,21 @@ module Elastic
           url.to_s.gsub(/\/\/(.+):(.+)@/, '//' + '\1:' + SANITIZED_PASSWORD + '@')
         end
 
+        def opentelemetry?
+          defined?(::OpenTelemetry)
+        end
+
         def capture_otel_span_attributes(connection, url)
-          if defined?(::OpenTelemetry)
+          if opentelemetry?
             ::OpenTelemetry::Trace.current_span&.set_attribute('url.full', sanitize_url(url))
             ::OpenTelemetry::Trace.current_span&.set_attribute('server.address', connection.host[:host])
             ::OpenTelemetry::Trace.current_span&.set_attribute('server.port', connection.host[:port].to_i)
+          end
+        end
+
+        def capture_otel_error_attributes(error)
+          if opentelemetry?
+            ::OpenTelemetry::Trace.current_span&.set_attribute('error.type', error)
           end
         end
       end

--- a/lib/elastic/transport/transport/http/faraday.rb
+++ b/lib/elastic/transport/transport/http/faraday.rb
@@ -40,7 +40,6 @@ module Elastic
               body, headers = compress_request(body, headers)
 
               response = connection.connection.run_request(method.downcase.to_sym, url, body, headers)
-
               Response.new(response.status, decompress_response(response.body), response.headers)
             end
           end

--- a/spec/elastic/transport/base_spec.rb
+++ b/spec/elastic/transport/base_spec.rb
@@ -137,7 +137,7 @@ describe Elastic::Transport::Transport::Base do
 
       it 'retries on 404 status the specified number of max_retries' do
         expect do
-          client.transport.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
+          client.transport.perform_request('GET', 'myindex/_doc/42?routing=FOOBARBAZ', {}, nil, nil, retry_on_failure: 5)
         end.to raise_exception(Elastic::Transport::Transport::Errors::NotFound)
       end
     end

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -1730,7 +1730,7 @@ describe Elastic::Transport::Client do
           client.transport.reload_connections!
           response = client.perform_request('GET', '_nodes/stats/http')
           connections_after = response.body['nodes'].values.find { |n| n['name'] == node_names.first }['http']['total_opened']
-          expect(connections_after).to be >= (connections_before)
+          expect(connections_after).to be >= connections_before
         end
       end
     end

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -134,7 +134,6 @@ describe Elastic::Transport::Client do
     end
 
     context 'when a User-Agent header is specified as a client option' do
-
       let(:client) do
         described_class.new(transport_class: Elastic::Transport::Transport::HTTP::Curb,
                             transport_options: { headers: { 'User-Agent' => 'testing' } })
@@ -1619,7 +1618,7 @@ describe Elastic::Transport::Client do
       context 'when an invalid url is specified' do
         it 'raises an exception' do
           expect {
-            client.perform_request('GET', 'myindex/_doc/1?routing=FOOBARBAZ')
+            client.perform_request('GET', 'myindex/_doc/42?routing=FOOBARBAZ')
           }.to raise_exception(Elastic::Transport::Transport::Errors::NotFound)
         end
       end

--- a/spec/elastic/transport/opentelemetry_spec.rb
+++ b/spec/elastic/transport/opentelemetry_spec.rb
@@ -261,6 +261,16 @@ if defined?(::OpenTelemetry)
       end
     end
 
+    context 'when there is an error' do
+      it 'it sets error.type' do
+        expect do
+          client.perform_request('GET', '/_wrongendpoint', nil, nil, nil, endpoint: 'wrong')
+        end.to raise_error
+
+        expect(span.attributes['error.type']).to match(/error/)
+      end
+    end
+
     context 'when the ENV variable OTEL_RUBY_INSTRUMENTATION_ELASTICSEARCH_ENABLED is set' do
       context 'to true' do
         around do |ex|

--- a/spec/elastic/transport/opentelemetry_spec.rb
+++ b/spec/elastic/transport/opentelemetry_spec.rb
@@ -74,6 +74,7 @@ if defined?(::OpenTelemetry)
         expect(span.attributes['server.address']).to eq('localhost')
         expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)
         expect(span.attributes['kind']).to eq('CLIENT')
+        expect(span.attributes['db.response.status_code']).to eq(201)
       end
 
       context 'with list a path parameter' do
@@ -93,6 +94,7 @@ if defined?(::OpenTelemetry)
           expect(span.attributes['server.address']).to eq('localhost')
           expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)
           expect(span.attributes['kind']).to eq('CLIENT')
+          expect(span.attributes['db.response.status_code']).to eq(200)
         end
       end
     end

--- a/spec/elastic/transport/opentelemetry_spec.rb
+++ b/spec/elastic/transport/opentelemetry_spec.rb
@@ -65,32 +65,34 @@ if defined?(::OpenTelemetry)
 
         span = exporter.finished_spans.find { |s| s.name == 'create' }
         expect(span.name).to eql('create')
-        expect(span.attributes['db.system']).to eql('elasticsearch')
-        expect(span.attributes['db.elasticsearch.path_parts.index']).to eql('users')
-        expect(span.attributes['db.elasticsearch.path_parts.id']).to eq('abc')
-        expect(span.attributes['db.operation']).to eq('create')
+        expect(span.attributes['db.system.name']).to eql('elasticsearch')
+        expect(span.attributes['db.operation.parameter.index']).to eql('users')
+        expect(span.attributes['db.operation.parameter.id']).to eq('abc')
+        expect(span.attributes['db.operation.name']).to eq('create')
         expect(span.attributes['db.statement']).to be_nil
         expect(span.attributes['http.request.method']).to eq('POST')
         expect(span.attributes['server.address']).to eq('localhost')
         expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)
+        expect(span.attributes['kind']).to eq('CLIENT')
       end
 
       context 'with list a path parameter' do
         it 'creates a span with path parameters' do
           client.perform_request(
             'GET', '_cluster/state/foo,bar', {}, nil, {},
-            { defined_params: { metric: ['foo', 'bar']}, endpoint: 'cluster.state' }
+            { defined_params: { metric: ['foo', 'bar'] }, endpoint: 'cluster.state' }
           )
 
           span = exporter.finished_spans.find { |s| s.name == 'cluster.state' }
           expect(span.name).to eql('cluster.state')
-          expect(span.attributes['db.system']).to eql('elasticsearch')
-          expect(span.attributes['db.elasticsearch.path_parts.metric']).to eql('foo,bar')
-          expect(span.attributes['db.operation']).to eq('cluster.state')
-          expect(span.attributes['db.statement']).to be_nil
+          expect(span.attributes['db.system.name']).to eql('elasticsearch')
+          expect(span.attributes['db.operation.parameter.metric']).to eql('foo,bar')
+          expect(span.attributes['db.operation.name']).to eq('cluster.state')
+          expect(span.attributes['db.query.text']).to be_nil
           expect(span.attributes['http.request.method']).to eq('GET')
           expect(span.attributes['server.address']).to eq('localhost')
           expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)
+          expect(span.attributes['kind']).to eq('CLIENT')
         end
       end
     end
@@ -100,13 +102,13 @@ if defined?(::OpenTelemetry)
         { query: { match: { password: { query: 'secret' } } } }
       end
 
-      it 'creates a span and omits db.statement' do
+      it 'creates a span and omits db.query.text' do
         client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
 
         expect(span.name).to eql('search')
-        expect(span.attributes['db.system']).to eql('elasticsearch')
-        expect(span.attributes['db.operation']).to eq('search')
-        expect(span.attributes['db.statement']).to be_nil
+        expect(span.attributes['db.system.name']).to eql('elasticsearch')
+        expect(span.attributes['db.operation.name']).to eq('search')
+        expect(span.attributes['db.query.text']).to be_nil
         expect(span.attributes['http.request.method']).to eq('GET')
         expect(span.attributes['server.address']).to eq('localhost')
         expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)
@@ -128,7 +130,7 @@ if defined?(::OpenTelemetry)
           it 'sanitizes the body' do
             client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
 
-            expect(span.attributes['db.statement']).to eq(sanitized_body.to_json)
+            expect(span.attributes['db.query.text']).to eq(sanitized_body.to_json)
           end
         end
 
@@ -147,13 +149,13 @@ if defined?(::OpenTelemetry)
           it 'sanitizes the body' do
             client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
 
-            expect(span.attributes['db.statement']).to eq(sanitized_body.to_json)
+            expect(span.attributes['db.query.text']).to eq(sanitized_body.to_json)
           end
         end
 
         context 'with custom keys' do
           let(:body) do
-            { query: { match: { sensitive: { query: 'secret'} } } }
+            { query: { match: { sensitive: { query: 'secret' } } } }
           end
 
           let(:sanitized_body) do
@@ -176,7 +178,7 @@ if defined?(::OpenTelemetry)
           it 'sanitizes the body' do
             client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
 
-            expect(span.attributes['db.statement']).to eq(sanitized_body.to_json)
+            expect(span.attributes['db.query.text']).to eq(sanitized_body.to_json)
           end
         end
       end
@@ -196,14 +198,14 @@ if defined?(::OpenTelemetry)
         context 'when the body is a string' do
           it 'includes the raw body' do
             client.perform_request('GET', '/_search', nil, body.to_json, nil, endpoint: 'search')
-            expect(span.attributes['db.statement']).to eq(body.to_json)
+            expect(span.attributes['db.query.text']).to eq(body.to_json)
           end
         end
 
         context' when the body is a hash' do
           it 'includes the raw body' do
             client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
-            expect(span.attributes['db.statement']).to eq(body.to_json)
+            expect(span.attributes['db.query.text']).to eq(body.to_json)
           end
         end
       end
@@ -222,7 +224,7 @@ if defined?(::OpenTelemetry)
 
         it 'does not include anything' do
           client.perform_request('GET', '/_search', nil, body, nil, endpoint: 'search')
-          expect(span.attributes['db.statement']).to be_nil
+          expect(span.attributes['db.query.text']).to be_nil
         end
       end
 
@@ -231,12 +233,12 @@ if defined?(::OpenTelemetry)
           { query: { match: { something: "test" } } }
         end
 
-        it 'does not capture db.statement' do
+        it 'does not capture db.query.text' do
           client.perform_request(
             'POST', '_all/_delete_by_query', nil, body, nil, endpoint: 'delete_by_query'
           )
 
-          expect(span.attributes['db.statement']).to be_nil
+          expect(span.attributes['db.query.text']).to be_nil
         end
       end
 
@@ -248,10 +250,10 @@ if defined?(::OpenTelemetry)
 
           span = exporter.finished_spans.find { |s| s.name == 'GET' }
           expect(span.name).to eql('GET')
-          expect(span.attributes['db.system']).to eql('elasticsearch')
-          expect(span.attributes['db.elasticsearch.path_parts']).to be_nil
+          expect(span.attributes['db.system.name']).to eql('elasticsearch')
+          expect(span.attributes['db.operation.parameter']).to be_nil
           expect(span.attributes['db.operation']).to be_nil
-          expect(span.attributes['db.statement']).to be_nil
+          expect(span.attributes['db.query.text']).to be_nil
           expect(span.attributes['http.request.method']).to eq('GET')
           expect(span.attributes['server.address']).to eq('localhost')
           expect(span.attributes['server.port']).to eq(TEST_PORT.to_i)

--- a/spec/elastic/transport/opentelemetry_spec.rb
+++ b/spec/elastic/transport/opentelemetry_spec.rb
@@ -338,7 +338,7 @@ if defined?(::OpenTelemetry)
 
       context 'sanitize in URL' do
         let(:client) {
-          Elastic::Transport::Client.new(host: 'http://elastic:changeme@localhost:9250')
+          Elastic::Transport::Client.new(host: "http://elastic:changeme@#{ELASTICSEARCH_HOSTS.first}")
         }
 
         it 'sanitizes URL' do
@@ -348,7 +348,7 @@ if defined?(::OpenTelemetry)
 
           span = exporter.finished_spans.find { |s| s.name == 'GET' }
           expect(span.name).to eql('GET')
-          expect(span.attributes['url.full']).to match(/http:\/\/elastic:\*+@localhost:9250/)
+          expect(span.attributes['url.full']).to match(/http:\/\/elastic:\*+@localhost:/)
         end
       end
     end


### PR DESCRIPTION
Updates OpenTelemetry span keys to stabilized definitions:
https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/elasticsearch.md#semantic-conventions-for-elasticsearch-client-operations