### PR TITLE
[Backport][8.5] Updates yard development dependency to > 0.9.42

### DIFF
--- a/elastic-transport.gemspec
+++ b/elastic-transport.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'shoulda-context'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit', '~> 2'
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'yard', '> 0.9.42'
 
   s.description = <<-DESC.gsub(/^    /, '')
     Low level Ruby client for Elastic. See the `elasticsearch` or `elastic-enterprise-search` gems for full integration.


### PR DESCRIPTION
Related to:
https://github.com/advisories/GHSA-xfhh-rx56-rxcr
https://github.com/advisories/GHSA-3jfp-46x4-xgfj