### PR TITLE
Addresses duplicate content-type header in Manticore

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '4.0'

--- a/.github/workflows/otel.yml
+++ b/.github/workflows/otel.yml
@@ -20,7 +20,7 @@ jobs:
         es_version: ['9.4.0-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Increase system limits
         run: |
           sudo swapoff -a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         es_version: ['8.19.14-SNAPSHOT', '9.2.8-SNAPSHOT', '9.3.3-SNAPSHOT', '9.4.0-SNAPSHOT']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Increase system limits
       run: |
         sudo swapoff -a

--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,14 @@ group :development, :test do
   gem 'faraday-typhoeus'
   gem 'mutex_m' if RUBY_VERSION >= '3.4'
   gem 'opentelemetry-sdk', require: false if RUBY_VERSION >= '3.0'
+  gem 'ostruct'
   if defined?(JRUBY_VERSION)
     gem 'pry-nav'
+    gem 'manticore', platform: :jruby
+    gem 'base64'
   else
     gem 'async-http-faraday'
+    gem 'curb'
     gem 'faraday-patron'
     gem 'oj'
     gem 'debug'

--- a/Gemfile-faraday1.gemfile
+++ b/Gemfile-faraday1.gemfile
@@ -31,8 +31,10 @@ group :development, :test do
   gem 'rspec'
   gem 'typhoeus'
   if defined?(JRUBY_VERSION)
+    gem 'manticore', platform: :jruby
     gem 'pry-nav'
   else
+    gem 'curb'
     gem 'debug'
     gem 'oj'
     gem 'patron'

--- a/elastic-transport.gemspec
+++ b/elastic-transport.gemspec
@@ -45,13 +45,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '< 3'
   s.add_dependency 'multi_json'
-
-  # Faraday Adapters
-  if defined? JRUBY_VERSION
-    s.add_development_dependency 'manticore'
-    s.add_development_dependency 'base64'
-  end
-  s.add_development_dependency 'curb' unless defined? JRUBY_VERSION
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cane'
   s.add_development_dependency 'hashie'

--- a/lib/elastic/transport/transport/base.rb
+++ b/lib/elastic/transport/transport/base.rb
@@ -396,7 +396,7 @@ module Elastic
         ACCEPT_ENCODING = 'Accept-Encoding'.freeze
         CONTENT_ENCODING = 'Content-Encoding'.freeze
         CONTENT_TYPE_STR = 'Content-Type'.freeze
-        CONTENT_TYPE_REGEX = /content-?_?type/.freeze
+        CONTENT_TYPE_REGEX = /content-?_?type/i.freeze
         DEFAULT_CONTENT_TYPE = 'application/json'.freeze
         GZIP = 'gzip'.freeze
         GZIP_FIRST_TWO_BYTES = '1f8b'.freeze

--- a/lib/elastic/transport/transport/http/manticore.rb
+++ b/lib/elastic/transport/transport/http/manticore.rb
@@ -64,11 +64,10 @@ module Elastic
 
           def initialize(arguments = {}, &block)
             @request_options = {
-              headers: (
+              headers:
                 arguments.dig(:transport_options, :headers) ||
                 arguments.dig(:options, :transport_options, :headers) ||
                 {}
-              )
             }
             @manticore = build_client(arguments[:options] || {})
             super(arguments, &block)
@@ -78,7 +77,6 @@ module Elastic
           def build_client(options = {})
             client_options = options[:transport_options] || {}
             client_options[:ssl] = options[:ssl] || {}
-
             @manticore = ::Manticore::Client.new(client_options)
           end
 
@@ -169,7 +167,12 @@ module Elastic
 
           def apply_headers(options)
             headers = options[:headers].clone || options.dig(:transport_options, :headers).clone || {}
-            headers[CONTENT_TYPE_STR] = find_value(headers, CONTENT_TYPE_REGEX) || DEFAULT_CONTENT_TYPE
+            if (value = find_value(headers, CONTENT_TYPE_REGEX))
+              @request_options[:headers].reject! { |k, _| k.match? CONTENT_TYPE_REGEX }
+              headers[CONTENT_TYPE_STR] = value
+            else
+              headers[CONTENT_TYPE_STR] = DEFAULT_CONTENT_TYPE
+            end
             headers[USER_AGENT_STR] = find_value(headers, USER_AGENT_REGEX) || find_value(@request_options[:headers], USER_AGENT_REGEX) || user_agent_header
             headers[ACCEPT_ENCODING] = GZIP if use_compression?
             @request_options[:headers].merge!(headers)

--- a/lib/elastic/transport/transport/http/manticore.rb
+++ b/lib/elastic/transport/transport/http/manticore.rb
@@ -118,7 +118,6 @@ module Elastic
           #
           def __build_connections
             apply_headers(options)
-
             Connections::Collection.new(
               connections: hosts.map do |host|
                 host[:protocol] = host[:scheme] || DEFAULT_PROTOCOL

--- a/spec/elastic/transport/client_spec.rb
+++ b/spec/elastic/transport/client_spec.rb
@@ -19,8 +19,8 @@ require 'spec_helper'
 
 describe Elastic::Transport::Client do
   let(:client) do
-    described_class.new.tap do |_client|
-      allow(_client).to receive(:__build_connections)
+    described_class.new.tap do |client|
+      allow(client).to receive(:__build_connections)
     end
   end
 
@@ -48,10 +48,6 @@ describe Elastic::Transport::Client do
     expect(client.transport.connections.first.connection.headers['User-Agent']).to match(/#{RbConfig::CONFIG['target_cpu']}/)
   end
 
-  it 'sets the \'Content-Type\' header to \'application/json\' by default' do
-    expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('application/json')
-  end
-
   it 'uses localhost by default' do
     expect(client.transport.hosts[0][:host]).to eq('localhost')
   end
@@ -67,7 +63,6 @@ describe Elastic::Transport::Client do
   end
 
   context 'when a user-agent header is specified as client option in lower-case' do
-
     let(:client) do
       described_class.new(transport_options: { headers: { 'user-agent' => 'testing' } })
     end
@@ -77,30 +72,7 @@ describe Elastic::Transport::Client do
     end
   end
 
-  context 'when a Content-Type header is specified as client option' do
-
-    let(:client) do
-      described_class.new(transport_options: { headers: { 'Content-Type' => 'testing' } })
-    end
-
-    it 'sets the specified Content-Type header' do
-      expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('testing')
-    end
-  end
-
-  context 'when a content-type header is specified as client option in lower-case' do
-
-    let(:client) do
-      described_class.new(transport_options: { headers: { 'content-type' => 'testing' } })
-    end
-
-    it 'sets the specified Content-Type header' do
-      expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('testing')
-    end
-  end
-
   context 'when the Curb transport class is used', unless: jruby? do
-
     let(:client) do
       described_class.new(transport_class: Elastic::Transport::Transport::HTTP::Curb)
     end
@@ -145,7 +117,6 @@ describe Elastic::Transport::Client do
     end
 
     context 'when a user-agent header is specified as a client option as lower-case' do
-
       let(:client) do
         described_class.new(transport_class: Elastic::Transport::Transport::HTTP::Curb,
                             transport_options: { headers: { 'user-agent' => 'testing' } })
@@ -157,7 +128,6 @@ describe Elastic::Transport::Client do
     end
 
     context 'when a Content-Type header is specified as client option' do
-
       let(:client) do
         described_class.new(transport_class: Elastic::Transport::Transport::HTTP::Curb,
                             transport_options: { headers: { 'Content-Type' => 'testing' } })
@@ -169,7 +139,6 @@ describe Elastic::Transport::Client do
     end
 
     context 'when a content-type header is specified as client option in lower-case' do
-
       let(:client) do
         described_class.new(transport_class: Elastic::Transport::Transport::HTTP::Curb,
                             transport_options: { headers: { 'content-type' => 'testing' } })

--- a/spec/elastic/transport/content_type_spec.rb
+++ b/spec/elastic/transport/content_type_spec.rb
@@ -1,0 +1,83 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+
+describe Elastic::Transport::Client do
+  let(:client) do
+    described_class.new.tap do |client|
+      allow(client).to receive(:__build_connections)
+    end
+  end
+
+  context 'Client' do
+    it 'sets the \'Content-Type\' header to \'application/json\' by default' do
+      expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('application/json')
+    end
+  end
+
+  context 'when a Content-Type header is specified as client option' do
+    let(:client) do
+      described_class.new(transport_options: { headers: { 'Content-Type' => 'testing' } })
+    end
+
+    it 'sets the specified Content-Type header' do
+      expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('testing')
+    end
+  end
+
+  context 'when a content-type header is specified as client option in lower-case' do
+    let(:client) do
+      described_class.new(transport_options: { headers: { 'content-type' => 'testing' } })
+    end
+
+    it 'sets the specified Content-Type header' do
+      expect(client.transport.connections.first.connection.headers['Content-Type']).to eq('testing')
+    end
+  end
+
+  if jruby?
+    context 'when using JRuby' do
+      let(:client) do
+        Elastic::Transport::Client.new(
+          transport_class: Elastic::Transport::Transport::HTTP::Manticore,
+          transport_options: { headers: headers }
+        )
+      end
+
+      let(:connection_headers) {
+        client.transport.connections.connections.first.connection.instance_variable_get('@options')[:headers]
+      }
+
+      context 'when a Content-Type header is specified as client option' do
+        let(:headers) { { 'Content-Type' => 'testing' } }
+
+        it 'sets the specified Content-Type header' do
+          expect(connection_headers['Content-Type']).to eq('testing')
+        end
+      end
+
+      context 'when a content-type header is specified as client option in lower-case' do
+        let(:headers) { { 'content-type' => 'testing' } }
+
+        it 'sets the specified Content-Type header' do
+          expect(connection_headers['Content-Type']).to eq('testing')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Logstash CI started failing because it rewrites the Content-Type header and ES is rejecting requests due to duplicate headers `[Content-Type, content-type]` (capital and small letters difference).

I believe this is not an issue when using Faraday because it uses `Faraday::Utils::Headers`, a case-insensitive Hash.

Addresses [elasticsearch-ruby/issues/#2961](https://github.com/elastic/elasticsearch-ruby/issues/2961)