### PR TITLE
Fix serializer crash when multi_json is loaded without RubyGems activation

### DIFF
--- a/lib/elastic/transport/transport/serializer/multi_json.rb
+++ b/lib/elastic/transport/transport/serializer/multi_json.rb
@@ -56,8 +56,14 @@ module Elastic
 
           private
 
+          # multi_json 1.21.0 renamed the top-level constant to `MultiJSON` (keeping a
+          # deprecated `MultiJson` alias), so the constant's absence indicates a deprecated
+          # version. Checking the constant rather than `Gem.loaded_specs` also works when
+          # the gem is loaded without RubyGems activation (e.g. from a `bundle install
+          # --standalone` bundle or a vendored load path), where `Gem.loaded_specs` is
+          # empty and the version lookup would raise a `NoMethodError` on `nil`.
           def deprecated_gem_version_loaded?
-            Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.21.0')
+            !defined?(::MultiJSON)
           end
         end
       end

--- a/test/unit/serializer_test.rb
+++ b/test/unit/serializer_test.rb
@@ -22,16 +22,25 @@ class Elastic::Transport::Transport::SerializerTest < Minitest::Test
   context "Serializer" do
 
     should "use MultiJSON by default" do
-      if Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.21.0')
-        ::MultiJson.expects(:load)
-        ::MultiJson.expects(:dump)
-      else
+      if defined?(::MultiJSON)
         ::MultiJSON.expects(:parse)
         ::MultiJSON.expects(:generate)
+      else
+        ::MultiJson.expects(:load)
+        ::MultiJson.expects(:dump)
       end
 
       Elastic::Transport::Transport::Serializer::MultiJson.new.load('{}')
       Elastic::Transport::Transport::Serializer::MultiJson.new.dump({})
+    end
+
+    should "work when multi_json is loaded without RubyGems activation" do
+      # When gems are loaded from a plain $LOAD_PATH (e.g. a `bundle install --standalone`
+      # bundle or a vendored load path), they are not registered in Gem.loaded_specs.
+      Gem.stubs(:loaded_specs).returns({})
+
+      assert_equal({ 'foo' => 'bar' }, Elastic::Transport::Transport::Serializer::MultiJson.new.load('{"foo":"bar"}'))
+      assert_equal('{"foo":"bar"}', Elastic::Transport::Transport::Serializer::MultiJson.new.dump({ 'foo' => 'bar' }))
     end
 
   end


### PR DESCRIPTION
## Problem

Since 8.5.2, `Serializer::MultiJson#deprecated_gem_version_loaded?` chooses between the deprecated `MultiJson` API and the new `MultiJSON` API (multi_json >= 1.21.0) by consulting:

```ruby
Gem.loaded_specs['multi_json'].version < Gem::Version.create('1.21.0')
```

`Gem.loaded_specs` is only populated when gems are activated through RubyGems. When gems are loaded from a plain `$LOAD_PATH` — e.g. a `bundle install --standalone` bundle, or a vendored load path — the lookup returns `nil`, and every request fails during response deserialization:

```
NoMethodError: undefined method 'version' for nil
  .../lib/elastic/transport/transport/serializer/multi_json.rb:60:in 'deprecated_gem_version_loaded?'
  .../lib/elastic/transport/transport/serializer/multi_json.rb:40:in 'load'
  .../lib/elastic/transport/transport/base.rb:362:in 'perform_request'
```

8.5.1 and earlier were unaffected (the serializer called `::MultiJson` directly, without consulting gem specs). We hit this in [ElasticGraph's CI](https://github.com/block/elasticgraph/pull/1290), which runs part of its test suite from a standalone bundle, and pinned to 8.5.1 to work around it.

### Reproduction

```console
$ mkdir repro && cd repro
$ printf 'source "https://rubygems.org"\ngem "elastic-transport", "8.5.3"\n' > Gemfile
$ bundle install --standalone
$ ruby -rbundle/bundler/setup -relastic/transport -e \
    'p Elastic::Transport::Transport::Serializer::MultiJson.new.load("{}")'
.../serializer/multi_json.rb:60:in 'deprecated_gem_version_loaded?':
undefined method 'version' for nil (NoMethodError)
```

## Fix

Detect which multi_json API is available by checking for the `MultiJSON` constant instead. multi_json 1.21.0 is exactly the version that introduced that constant, so the check is behaviorally equivalent to the version comparison — and it works regardless of how the gem was loaded.

## Testing

- Updated the existing serializer unit test to branch on the same constant check.
- Added a regression test that stubs `Gem.loaded_specs` to be empty; it fails with the production `NoMethodError` before this change and passes after.
- Manually verified round-trip serialization with both multi_json 1.15.0 (deprecated `MultiJson` API) and 1.21.1 (`MultiJSON` API) loaded from a plain `$LOAD_PATH` without RubyGems activation.

One note from running `rake test:unit` locally (macOS, Ruby 3.4.7): the `connection_test.rb` resurrect tests fail intermittently both with and without this change (they appear to be ordering/seed-sensitive), while the serializer tests pass consistently.

Related: #125 is a different symptom in the same version-detection code path; this PR doesn't address it.